### PR TITLE
Various signed / const / type / format fixes

### DIFF
--- a/libparse/clk_trimtsip.c
+++ b/libparse/clk_trimtsip.c
@@ -251,7 +251,7 @@ cvt_trimtsip(
 		    case CMD_RCURTIME:
 			    {			/* GPS time */
 				    l_fp secs;
-				    int   week = getshort((unsigned char *)&mb(4));
+				    unsigned int   week = getshort((unsigned char *)&mb(4));
 				    l_fp utcoffset;
 				    l_fp gpstime;
 

--- a/libparse/gpstolfp.c
+++ b/libparse/gpstolfp.c
@@ -39,12 +39,13 @@
 
 void
 gpstolfp(
-	 int weeks,
+	 int sweeks,
 	 int days,
 	 unsigned long  seconds,
 	 l_fp * lfp
 	 )
 {
+  unsigned int weeks = sweeks;
   if (weeks < GPSWRAP)
     {
       weeks += GPSWEEKS;

--- a/ntpd/ntp_config.c
+++ b/ntpd/ntp_config.c
@@ -53,6 +53,8 @@
 #include "ntp_parser.h"
 #include "ntpd-opts.h"
 
+int yyparse(void);
+
 /* Bug 2817 */
 #if defined(HAVE_SYS_MMAN_H)
 # include <sys/mman.h>

--- a/ntpd/ntp_io.c
+++ b/ntpd/ntp_io.c
@@ -3265,7 +3265,7 @@ read_refclock_packet(
 	/* TALOS-CAN-0064: avoid signed/unsigned clashes that can lead
 	 * to buffer overrun and memory corruption
 	 */
-	if (rp->datalen <= 0 || rp->datalen > sizeof(rb->recv_space))
+	if (rp->datalen <= 0 || (size_t)rp->datalen > sizeof(rb->recv_space))
 		read_count = sizeof(rb->recv_space);
 	else
 		read_count = (u_int)rp->datalen;

--- a/ntpd/ntp_proto.c
+++ b/ntpd/ntp_proto.c
@@ -2520,6 +2520,7 @@ clock_select(void)
 {
 	struct peer *peer;
 	int	i, j, k, n;
+	u_int	l;
 	int	nlist, nl2;
 	int	allow;
 	int	speer;
@@ -2831,10 +2832,10 @@ clock_select(void)
 	/*
 	 * Mark the candidates at this point as truechimers.
 	 */
-	for (i = 0; i < nlist; i++) {
-		peers[i].peer->new_status = CTL_PST_SEL_SELCAND;
+	for (l = 0; l < nlist; l++) {
+		peers[l].peer->new_status = CTL_PST_SEL_SELCAND;
 		DPRINTF(2, ("select: survivor %s %f\n",
-			stoa(&peers[i].peer->srcadr), peers[i].synch));
+			stoa(&peers[l].peer->srcadr), peers[l].synch));
 	}
 
 	/*

--- a/ntpd/ntp_scanner.c
+++ b/ntpd/ntp_scanner.c
@@ -669,7 +669,7 @@ int
 yylex(void)
 {
 	static follby	followedby = FOLLBY_TOKEN;
-	int		i;
+	size_t		i;
 	int		instring;
 	int		yylval_was_set;
 	int		converted;

--- a/ntpd/ntp_timer.c
+++ b/ntpd/ntp_timer.c
@@ -655,7 +655,7 @@ check_leapsec(
 		sys_tai = lsdata.tai_offs;
 	  } else {
 #ifdef AUTOKEY
-		update_autokey = (sys_tai != lsdata.tai_offs);
+	    update_autokey = (sys_tai != (u_int)lsdata.tai_offs);
 #endif
 		lsprox  = lsdata.proximity;
 		sys_tai = lsdata.tai_offs;

--- a/ntpd/ntp_timer.c
+++ b/ntpd/ntp_timer.c
@@ -655,7 +655,7 @@ check_leapsec(
 		sys_tai = lsdata.tai_offs;
 	  } else {
 #ifdef AUTOKEY
-	    update_autokey = (sys_tai != (u_int)lsdata.tai_offs);
+		update_autokey = (sys_tai != (u_int)lsdata.tai_offs);
 #endif
 		lsprox  = lsdata.proximity;
 		sys_tai = lsdata.tai_offs;

--- a/ntpd/refclock_chu.c
+++ b/ntpd/refclock_chu.c
@@ -1180,6 +1180,7 @@ chu_a(
 	int	val;		/* distance */
 	int	temp;
 	int	i, j, k;
+	u_int	l;
 
 	pp = peer->procptr;
 	up = pp->unitptr;
@@ -1259,13 +1260,13 @@ chu_a(
 		up->second = pp->second = 30 + temp;
 		offset.l_ui = 30 + temp;
 		offset.l_uf = 0;
-		i = 0;
+		l = 0;
 		if (k < 0)
 			offset = up->charstamp;
 		else if (k > 0)
-			i = 1;
-		for (; i < nchar && i < k + 10; i++) {
-			up->tstamp[up->ntstamp] = up->cstamp[i];
+			l = 1;
+		for (; l < nchar && l < k + 10; l++) {
+			up->tstamp[up->ntstamp] = up->cstamp[l];
 			L_SUB(&up->tstamp[up->ntstamp], &offset);
 			L_ADD(&offset, &up->charstamp);
 			if (up->ntstamp < MAXSTAGE - 1)

--- a/ntpd/refclock_gpsdjson.c
+++ b/ntpd/refclock_gpsdjson.c
@@ -1509,7 +1509,7 @@ process_version(
  */
 	snprintf(up->buffer, sizeof(up->buffer),
 	    "?WATCH={\"device\":\"%s\",\"enable\":true,\"json\":true%s};\r\n",
-	    up->device, up->pt_toff ? ",\"pps\":true" : "");
+	    up->device, up->pf_toff ? ",\"pps\":true" : "");
 	buf = up->buffer;
 	len = strlen(buf);
 	log_data(peer, "send", buf, len);

--- a/ntpd/refclock_gpsdjson.c
+++ b/ntpd/refclock_gpsdjson.c
@@ -1134,9 +1134,11 @@ strtojint(
 static tok_ref
 json_token_skip(
 	const json_ctx * ctx,
-	tok_ref          tid)
+	tok_ref          stid)
 {
-	if (tid >= 0 && tid < ctx->ntok) {
+	u_int tid = stid;
+
+	if (tid < ctx->ntok) {
 		int len = ctx->tok[tid].size;
 		/* For arrays and objects, the size is the number of
 		 * ITEMS in the compound. Thats the number of objects in

--- a/ntpd/refclock_jjy.c
+++ b/ntpd/refclock_jjy.c
@@ -702,7 +702,7 @@ jjy_receive ( struct recvbuf *rbufp )
 				up->iLineBufLen ++ ;
 
 				/* Copy printable characters */
-				if ( ! iscntrl( up->sRawBuf[i] ) ) {
+				if ( ! iscntrl( (unsigned char)up->sRawBuf[i] ) ) {
 					up->sTextBuf[up->iTextBufLen] = up->sRawBuf[i] ;
 					up->iTextBufLen ++ ;
 				}

--- a/ntpd/refclock_jjy.c
+++ b/ntpd/refclock_jjy.c
@@ -627,7 +627,7 @@ jjy_receive ( struct recvbuf *rbufp )
 #ifdef DEBUG
 	printf( "\nrefclock_jjy.c : %s : Len=%d  ", sFunctionName, pp->lencode ) ;
 	for ( i = 0 ; i < pp->lencode ; i ++ ) {
-	  if ( iscntrl( (unsigned char)pp->a_lastcode[i] & 0x7F ) ) {
+		if ( iscntrl( (unsigned char)pp->a_lastcode[i] & 0x7F ) ) {
 			printf( "<x%02X>", pp->a_lastcode[i] & 0xFF ) ;
 		} else {
 			printf( "%c", pp->a_lastcode[i] ) ;
@@ -2716,7 +2716,7 @@ jjy_start_telephone ( int unit, struct peer *peer, struct jjyunit *up )
 
 	iNumberOfDigitsOfPhoneNumber = iCommaCount = iCommaPosition = iFirstThreeDigitsCount = 0 ;
 	for ( i = 0 ; i < strlen( sys_phone[0] ) ; i ++ ) {
-	  if ( isdigit( (unsigned char)*(sys_phone[0]+i) ) ) {
+		if ( isdigit( (unsigned char)*(sys_phone[0]+i) ) ) {
 			if ( iFirstThreeDigitsCount < sizeof(sFirstThreeDigits)-1 ) {
 				sFirstThreeDigits[iFirstThreeDigitsCount++] = *(sys_phone[0]+i) ;
 			}

--- a/ntpd/refclock_parse.c
+++ b/ntpd/refclock_parse.c
@@ -4227,14 +4227,17 @@ parse_process(
 static void
 mk_utcinfo(
 	   char *t,  // pointer to the output string buffer
-	   int wnt,
-	   int wnlsf,
+	   int swnt,
+	   int swnlsf,
 	   int dn,
 	   int dtls,
 	   int dtlsf,
 	   int size  // size of the output string buffer
 	   )
 {
+	unsigned int wnt = swnt;
+	unsigned int wnlsf = swnlsf;
+
 	/*
 	 * The week number transmitted by the GPS satellites for the leap date
 	 * is truncated to 8 bits only. If the nearest leap second date is off

--- a/ntpd/refclock_shm.c
+++ b/ntpd/refclock_shm.c
@@ -600,7 +600,7 @@ shm_timer(
 		     cd.year, cd.month, cd.monthday,
 		     cd.hour, cd.minute, cd.second,
 		     (long)shm_stat.tvt.tv_nsec);
-	pp->lencode = (c < sizeof(pp->a_lastcode)) ? c : 0;
+	pp->lencode = ((size_t)c < sizeof(pp->a_lastcode)) ? c : 0;
 
 	/* check 1: age control of local time stamp */
 	tt = shm_stat.tvc.tv_sec - shm_stat.tvr.tv_sec;

--- a/ntpq/ntpq.c
+++ b/ntpq/ntpq.c
@@ -364,7 +364,7 @@ u_int numassoc;		/* number of cached associations */
 /*
  * For commands typed on the command line (with the -c option)
  */
-int numcmds = 0;
+size_t numcmds = 0;
 const char *ccmds[MAXCMDS];
 #define	ADDCMD(cp)	if (numcmds < MAXCMDS) ccmds[numcmds++] = (cp)
 
@@ -448,7 +448,7 @@ ntpqmain(
 	)
 {
 	u_int ihost;
-	int icmd;
+	size_t icmd;
 
 
 #ifdef SYS_VXWORKS
@@ -471,7 +471,8 @@ ntpqmain(
 
 	{
 	    char *list;
-	    char *msg, *fmt;
+	    char *msg;
+	    const char *fmt;
 
 	    list = list_digest_names();
 	    for (icmd = 0; icmd < sizeof(builtins)/sizeof(builtins[0]); icmd++) {
@@ -485,13 +486,15 @@ ntpqmain(
 
 #ifdef OPENSSL
 	    builtins[icmd].desc[0] = "digest-name";
-	    fmt = "set key type to use for authenticated requests, one of:%s";
+	    fmt = ", one of:";
 #else
 	    builtins[icmd].desc[0] = "md5";
-	    fmt = "set key type to use for authenticated requests (%s)";
+	    fmt = ":";
 #endif
 	    msg = emalloc(strlen(fmt) + strlen(list) - strlen("%s") +1);
-	    sprintf(msg, fmt, list);
+	    sprintf(msg,
+		    "set key type to use for authenticated requests%s %s",
+		    fmt, list);
 	    builtins[icmd].comment = msg;
 	    free(list);
 	}
@@ -3496,7 +3499,7 @@ static void list_md_fn(const EVP_MD *m, const char *from, const char *to, void *
     /* Lowercase names aren't accepted by keytype_from_text in ssl_init.c */
 
     for( cp = name; *cp; cp++ ) {
-	if( islower(*cp) )
+	if( islower((unsigned char)*cp) )
 	    return;
     }
     len = (cp - name) + 1;

--- a/ntpq/ntpq.c
+++ b/ntpq/ntpq.c
@@ -491,10 +491,11 @@ ntpqmain(
 	    builtins[icmd].desc[0] = "md5";
 	    fmt = ":";
 #endif
-	    msg = emalloc(strlen(fmt) + strlen(list) - strlen("%s") +1);
-	    sprintf(msg,
-		    "set key type to use for authenticated requests%s %s",
-		    fmt, list);
+#define FMT_STRING "set key type to use for authenticated requests%s %s"
+	    msg = emalloc(strlen(FMT_STRING) + strlen(fmt) + 
+			  strlen(list) - strlen("%s") +1);
+	    sprintf(msg, FMT_STRING, fmt, list);
+#undef FMT_STRING
 	    builtins[icmd].comment = msg;
 	    free(list);
 	}

--- a/sntp/libopts/configfile.c
+++ b/sntp/libopts/configfile.c
@@ -184,7 +184,7 @@ optionFindValue(const tOptDesc * odesc, char const * name, char const * val)
     else do {
         tArgList * argl  = odesc->optCookie;
         int        argct = argl->useCt;
-        void **    poptv = (void **)(argl->apzArgs);
+        const void **    poptv = (void **)(argl->apzArgs);
 
         if (argct == 0) {
             errno = ENOENT;
@@ -192,7 +192,7 @@ optionFindValue(const tOptDesc * odesc, char const * name, char const * val)
         }
 
         if (name == NULL) {
-            res = (tOptionValue *)*poptv;
+            res = (const tOptionValue *)*poptv;
             break;
         }
 
@@ -249,7 +249,7 @@ optionFindNextValue(const tOptDesc * odesc, const tOptionValue * pPrevVal,
                     char const * pzName, char const * pzVal)
 {
     bool old_found = false;
-    tOptionValue * res = NULL;
+    const tOptionValue * res = NULL;
 
     (void)pzName;
     (void)pzVal;
@@ -266,10 +266,10 @@ optionFindNextValue(const tOptDesc * odesc, const tOptionValue * pPrevVal,
     else do {
         tArgList * argl = odesc->optCookie;
         int        ct   = argl->useCt;
-        void **   poptv = (void **)argl->apzArgs;
+        const void **   poptv = (void **)argl->apzArgs;
 
         while (--ct >= 0) {
-            tOptionValue * pOV = *(poptv++);
+            const tOptionValue * pOV = *(poptv++);
             if (old_found) {
                 res = pOV;
                 break;
@@ -316,7 +316,7 @@ tOptionValue const *
 optionGetValue(tOptionValue const * oov, char const * vname)
 {
     tArgList *     arg_list;
-    tOptionValue * res = NULL;
+    const tOptionValue * res = NULL;
 
     if ((oov == NULL) || (oov->valType != OPARG_TYPE_HIERARCHY)) {
         errno = EINVAL;
@@ -326,13 +326,13 @@ optionGetValue(tOptionValue const * oov, char const * vname)
 
     if (arg_list->useCt > 0) {
         int     ct     = arg_list->useCt;
-        void ** ovlist = (void **)(arg_list->apzArgs);
+        const void ** ovlist = (void **)(arg_list->apzArgs);
 
         if (vname == NULL) {
-            res = (tOptionValue *)*ovlist;
+            res = (const tOptionValue *)*ovlist;
 
         } else do {
-            tOptionValue * opt_val = *(ovlist++);
+            const tOptionValue * opt_val = *(ovlist++);
             if (strcmp(opt_val->pzName, vname) == 0) {
                 res = opt_val;
                 break;
@@ -375,7 +375,7 @@ tOptionValue const *
 optionNextValue(tOptionValue const * ov_list,tOptionValue const * oov )
 {
     tArgList *     arg_list;
-    tOptionValue * res = NULL;
+    const tOptionValue * res = NULL;
     int            err = EINVAL;
 
     if ((ov_list == NULL) || (ov_list->valType != OPARG_TYPE_HIERARCHY)) {
@@ -385,17 +385,17 @@ optionNextValue(tOptionValue const * ov_list,tOptionValue const * oov )
     arg_list = ov_list->v.nestVal;
     {
         int     ct    = arg_list->useCt;
-        void ** o_list = (void **)(arg_list->apzArgs);
+        const void ** o_list = (void **)(arg_list->apzArgs);
 
         while (ct-- > 0) {
-            tOptionValue * nov = *(o_list++);
+            const tOptionValue * nov = *(o_list++);
             if (nov == oov) {
                 if (ct == 0) {
                     err = ENOENT;
 
                 } else {
                     err = 0;
-                    res = (tOptionValue *)*o_list;
+                    res = (const tOptionValue *)*o_list;
                 }
                 break;
             }

--- a/sntp/libopts/configfile.c
+++ b/sntp/libopts/configfile.c
@@ -184,7 +184,7 @@ optionFindValue(const tOptDesc * odesc, char const * name, char const * val)
     else do {
         tArgList * argl  = odesc->optCookie;
         int        argct = argl->useCt;
-        const void **    poptv = (void **)(argl->apzArgs);
+        const void **    poptv = VOIDP(argl->apzArgs);
 
         if (argct == 0) {
             errno = ENOENT;
@@ -266,7 +266,7 @@ optionFindNextValue(const tOptDesc * odesc, const tOptionValue * pPrevVal,
     else do {
         tArgList * argl = odesc->optCookie;
         int        ct   = argl->useCt;
-        const void **   poptv = (void **)argl->apzArgs;
+        const void **   poptv = VOIDP(argl->apzArgs);
 
         while (--ct >= 0) {
             const tOptionValue * pOV = *(poptv++);
@@ -326,7 +326,7 @@ optionGetValue(tOptionValue const * oov, char const * vname)
 
     if (arg_list->useCt > 0) {
         int     ct     = arg_list->useCt;
-        const void ** ovlist = (void **)(arg_list->apzArgs);
+        const void ** ovlist = VOIDP(arg_list->apzArgs);
 
         if (vname == NULL) {
             res = (const tOptionValue *)*ovlist;
@@ -385,7 +385,7 @@ optionNextValue(tOptionValue const * ov_list,tOptionValue const * oov )
     arg_list = ov_list->v.nestVal;
     {
         int     ct    = arg_list->useCt;
-        const void ** o_list = (void **)(arg_list->apzArgs);
+        const void ** o_list = VOIDP(arg_list->apzArgs);
 
         while (ct-- > 0) {
             const tOptionValue * nov = *(o_list++);

--- a/sntp/libopts/enum.c
+++ b/sntp/libopts/enum.c
@@ -215,7 +215,7 @@ find_name(char const * name, tOptions * pOpts, tOptDesc * pOD,
      *  Multiple partial matches means we have an ambiguous match.
      */
     for (idx = 0; idx < name_ct; idx++) {
-        if (strncmp(paz_names[idx], (const char *)name, len) == 0) {
+        if (strncmp(paz_names[idx], name, len) == 0) {
             if (paz_names[idx][len] == NUL)
                 return idx;  /* full match */
 

--- a/sntp/libopts/enum.c
+++ b/sntp/libopts/enum.c
@@ -189,7 +189,7 @@ find_name(char const * name, tOptions * pOpts, tOptDesc * pOD,
      *  The result gets stashed in a char * pointer.
      */
     uintptr_t   res = name_ct;
-    size_t      len = strlen((char *)name);
+    size_t      len = strlen(name);
     uintptr_t   idx;
 
     if (IS_DEC_DIGIT_CHAR(*name)) {
@@ -215,7 +215,7 @@ find_name(char const * name, tOptions * pOpts, tOptDesc * pOD,
      *  Multiple partial matches means we have an ambiguous match.
      */
     for (idx = 0; idx < name_ct; idx++) {
-        if (strncmp((char *)paz_names[idx], (char *)name, len) == 0) {
+        if (strncmp(paz_names[idx], (const char *)name, len) == 0) {
             if (paz_names[idx][len] == NUL)
                 return idx;  /* full match */
 

--- a/sntp/libopts/find.c
+++ b/sntp/libopts/find.c
@@ -80,7 +80,7 @@ parse_opt(char const ** nm_pp, char ** arg_pp, char * buf, size_t bufsz)
 
             buf[res] = NUL;
             *nm_pp   = buf;
-            *arg_pp  = (char *)p;
+            *arg_pp  = VOIDP(p);
             return res;
 
         default:

--- a/sntp/libopts/init.c
+++ b/sntp/libopts/init.c
@@ -98,14 +98,14 @@ validate_struct(tOptions * opts, char const * pname)
     if (opts->pzProgName == NULL) {
         char const *  pz = strrchr(pname, DIRCH);
         char const ** pp =
-            (char const **)(void **)&(opts->pzProgName);
+            VOIDP(&(opts->pzProgName));
 
         if (pz != NULL)
             *pp = pz+1;
         else
             *pp = pname;
 
-        pz = pathfind(getenv("PATH"), (char *)pname, "rx");
+        pz = pathfind(getenv("PATH"), pname, "rx");
         if (pz != NULL)
             pname = VOIDP(pz);
 

--- a/sntp/libopts/load.c
+++ b/sntp/libopts/load.c
@@ -225,7 +225,7 @@ add_prog_path(char * buf, int b_sz, char const * fname, char const * prg_path)
     if (strchr(prg_path, DIRCH) != NULL)
         path = prg_path;
     else {
-        path = pathfind(getenv("PATH"), (char *)prg_path, "rx");
+        path = pathfind(getenv("PATH"), prg_path, "rx");
 
         if (path == NULL)
             return false;

--- a/sntp/libopts/makeshell.c
+++ b/sntp/libopts/makeshell.c
@@ -401,7 +401,7 @@ emit_usage(tOptions * opts)
 
         /* Copy the program name into the time/name buffer */
         for (;;) {
-            if ((*pzPN++ = (char)tolower(*pz++)) == NUL)
+            if ((*pzPN++ = (char)tolower((unsigned char)*pz++)) == NUL)
                 break;
         }
 
@@ -671,8 +671,8 @@ emit_match_expr(char const * name, tOptDesc * cod, tOptions * opts)
                 continue;
 
             match_ct = 0;
-            while (  toupper(od->pz_DisableName[match_ct])
-                  == toupper(name[match_ct]))
+            while (  toupper((unsigned char)od->pz_DisableName[match_ct])
+                  == toupper((unsigned char)name[match_ct]))
                 match_ct++;
             if (match_ct > min_match_ct)
                 min_match_ct = match_ct;

--- a/sntp/libopts/nested.c
+++ b/sntp/libopts/nested.c
@@ -859,6 +859,7 @@ LOCAL int
 get_special_char(char const ** ppz, int * ct)
 {
     char const * pz = *ppz;
+    char *rz;
 
     if (*ct < 3)
         return '&';
@@ -872,7 +873,8 @@ get_special_char(char const ** ppz, int * ct)
             base = 16;
             pz++;
         }
-        retch = (int)strtoul(pz, (char **)&pz, base);
+        retch = (int)strtoul(pz, &rz, base);
+        pz = rz;
         if (*pz != ';')
             return '&';
         base = (int)(++pz - *ppz);

--- a/sntp/libopts/parse-duration.c
+++ b/sntp/libopts/parse-duration.c
@@ -70,7 +70,7 @@ str_const_to_ul (cch_t * str, cch_t ** ppz, int base)
 static long
 str_const_to_l (cch_t * str, cch_t ** ppz, int base)
 {
-  char pz;
+  char *pz;
   int rv = strtol (str, &pz, base);
   *ppz = pz;
   return rv;

--- a/sntp/libopts/parse-duration.c
+++ b/sntp/libopts/parse-duration.c
@@ -60,14 +60,20 @@ typedef enum {
 static unsigned long
 str_const_to_ul (cch_t * str, cch_t ** ppz, int base)
 {
-  return strtoul (str, (char **)ppz, base);
+  char *pz;
+  int rv = strtoul (str, &pz, base);
+  *ppz = pz;
+  return rv;
 }
 
 /* Wrapper around strtol that does not require a cast.  */
 static long
 str_const_to_l (cch_t * str, cch_t ** ppz, int base)
 {
-  return strtol (str, (char **)ppz, base);
+  char pz;
+  int rv = strtol (str, &pz, base);
+  *ppz = pz;
+  return rv;
 }
 
 /* Returns BASE + VAL * SCALE, interpreting BASE = BAD_TIME

--- a/sntp/libopts/reset.c
+++ b/sntp/libopts/reset.c
@@ -113,7 +113,7 @@ optionResetOpt(tOptions * pOpts, tOptDesc * pOD)
             assert(0 == 1);
         }
     } else {
-        succ = opt_find_long(pOpts, (char *)pzArg, &opt_state);
+        succ = opt_find_long(pOpts, pzArg, &opt_state);
         if (! SUCCESSFUL(succ)) {
             fprintf(stderr, zIllOptStr, pOpts->pzProgPath, pzArg);
             pOpts->pUsageProc(pOpts, EXIT_FAILURE);

--- a/sntp/libopts/save.c
+++ b/sntp/libopts/save.c
@@ -453,7 +453,7 @@ prt_val_list(FILE * fp, char const * name, tArgList * al)
     if (al == NULL)
         return;
     opt_ct   = al->useCt;
-    opt_list = (void **)al->apzArgs;
+    opt_list = VOIDP(al->apzArgs);
 
     if (opt_ct <= 0) {
         fprintf(fp, OPEN_CLOSE_FMT, name);
@@ -488,7 +488,7 @@ prt_nested(FILE * fp, tOptDesc * p)
         return;
 
     opt_ct   = al->useCt;
-    opt_list = (void **)al->apzArgs;
+    opt_list = VOIDP(al->apzArgs);
 
     if (opt_ct <= 0)
         return;

--- a/sntp/libopts/tokenize.c
+++ b/sntp/libopts/tokenize.c
@@ -57,7 +57,7 @@ copy_cooked(ch_t ** ppDest, char const ** ppSrc)
         case NUL:   *ppSrc = NULL; return;
         case '"':   goto done;
         case '\\':
-            pSrc += ao_string_cook_escape_char((char *)pSrc, (char *)&ch, 0x7F);
+            pSrc += ao_string_cook_escape_char((const char *)pSrc, (char *)&ch, 0x7F);
             if (ch == 0x7F)
                 break;
             /* FALLTHROUGH */


### PR DESCRIPTION
This is a set of changes mostly pulled from the NetBSD
repository, where ntp has been tweaked to build cleanly
with the set of warning flags we enable in our build.

There are a few additions which are of my own, which
came from trying to build the code after applying these
changes.

Ref. posting to hackers@lists.ntp.org, under the subject
"Patches for stricter compiler settings" of 29 Nov 2015.

Best regards,

Håvard
