### PR TITLE
refclock_shm.c: clear error status on clock recovery

### DIFF
--- a/ntpd/refclock_shm.c
+++ b/ntpd/refclock_shm.c
@@ -340,6 +340,7 @@ shm_poll(
         if (pp->coderecv != pp->codeproc) {
 		/* have some samples, everything OK */
 		pp->lastref = pp->lastrec;
+		refclock_report(peer, CEVNT_NOMINAL);
 		refclock_receive(peer);
 	} else if (NULL == up->shm) { /* is this possible at all? */
 		/* we're out of business without SHM access */


### PR DESCRIPTION
This approach does lead to the events counter ticking up every poll, but seems to be the method adopted in other refclocks, e.g. refclock_gpsdjson.c.