### PR TITLE
ntpq.html: fix typo

### DIFF
--- a/ntpq/ntpq.html
+++ b/ntpq/ntpq.html
@@ -1169,7 +1169,7 @@ The password must correspond to the key ID configured in <code>ntp.conf</code> f
 
      <br><dt><code><a name="raw"></a> raw</code><dd>Display server messages as received and without reformatting.
 
-     <br><dt><code><a name="timeout"></a> timeout </code><kbd>millseconds</kbd><dd>Specify a timeout period for responses to server queries. 
+     <br><dt><code><a name="timeout"></a> timeout </code><kbd>milliseconds</kbd><dd>Specify a timeout period for responses to server queries. 
 The default is about 5000 milliseconds. 
 Note that since <code>ntpq</code> retries each query once after a timeout
 the total waiting time for a timeout will be twice the timeout value set.


### PR DESCRIPTION
fix typo in "milliseconds"