### PR TITLE
Change max error and max estimate type to signed long

### DIFF
--- a/util/ntptime.c
+++ b/util/ntptime.c
@@ -311,8 +311,8 @@ main(
 		ts.l_uf &= ts_mask;
 		printf("  time %s, (.%0*d),\n",
 		       prettydate(&ts), fdigits, (int)time_frac);
-		printf("  maximum error %lu us, estimated error %lu us",
-		       (u_long)ntv.maxerror, (u_long)ntv.esterror);
+		printf("  maximum error %li us, estimated error %li us",
+		       ntv.maxerror, ntv.esterror);
 		if (rawtime)
 			printf("  ntptime=%x.%x unixtime=%x.%0*d %s",
 			       (u_int)ts.l_ui, (u_int)ts.l_uf,
@@ -344,8 +344,8 @@ main(
 		ftemp = (double)ntx.freq / SCALE_FREQ;
 		printf(" us, frequency %.3f ppm, interval %d s,\n",
 		     ftemp, 1 << ntx.shift);
-		printf("  maximum error %lu us, estimated error %lu us,\n",
-		     (u_long)ntx.maxerror, (u_long)ntx.esterror);
+		printf("  maximum error %li us, estimated error %li us,\n",
+		     ntx.maxerror, ntx.esterror);
 		printf("  status %s,\n", sprintb((u_int)ntx.status, TIMEX_STA_BITS));
 		ftemp = (double)ntx.tolerance / SCALE_FREQ;
 		gtemp = (double)ntx.precision;


### PR DESCRIPTION
The adjtimex system call returns type long (implied signed) for maxerror and esterror values.

See:
- https://manpages.ubuntu.com/manpages/xenial/man2/adjtimex.2.html
- https://github.com/torvalds/linux/blob/645ff1e8e704c4f33ab1fcd3c87f95cb9b6d7144/include/uapi/linux/timex.h#L68
- https://www.tutorialspoint.com/unix_system_calls/adjtimex.htm
- https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/time/ntp.c#n66
- https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/time/ntp.c#n69

The expectation and casting to unsigned long results in UB when running ntptime. The below segments are output from ntptime run 3 times on the same host within ~10 seconds. Note the variance between "maximum error" and "estimated error" values of each run.


`ntp_gettime() returns code 0 (OK)
  time dfd7f65c.52672fbc  Wed, Jan  2 2019 21:47:56.321, (.321887282),
  maximum error 496 us, estimated error 18446744073709551612 us, TAI offset 37
ntp_adjtime() returns code 0 (OK)
  modes 0x0 (),
  offset 0.000 us, frequency 7.972 ppm, interval 1 s,
  maximum error 496 us, estimated error 18446744073709551612 us,
  status 0x2001 (PLL,NANO),
  time constant 6, precision 0.001 us, tolerance 500 ppm,`

`
ntp_gettime() returns code 0 (OK)
  time dfd7f66a.e34a1274  Wed, Jan  2 2019 21:48:10.887, (.887849349),
  maximum error 18446744073709551615 us, estimated error 18446744073709551615 us, TAI offset 37
ntp_adjtime() returns code 0 (OK)
  modes 0x0 (),
  offset 0.000 us, frequency 7.668 ppm, interval 1 s,
  maximum error 18446744073709551615 us, estimated error 18446744073709551615 us,
  status 0x2001 (PLL,NANO),
  time constant 6, precision 0.001 us, tolerance 500 ppm,
`

`
ntp_gettime() returns code 0 (OK)
  time dfd7f678.9e5f0f5c  Wed, Jan  2 2019 21:48:24.618, (.618638187),
  maximum error 504 us, estimated error 4 us, TAI offset 37
ntp_adjtime() returns code 0 (OK)
  modes 0x0 (),
  offset 0.000 us, frequency 7.028 ppm, interval 1 s,
  maximum error 504 us, estimated error 4 us,
  status 0x2001 (PLL,NANO),
  time constant 6, precision 0.001 us, tolerance 500 ppm,
`